### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(name='Hadoop',
+      version='0.1.4',
+      description='Python Hadoop I/O Utilities',
+      license="Apache Software License 2.0 (ASF)",
+      author='Matteo Bertozzi',
+      author_email='theo.bertozzi@gmail.com',
+      url='http://hadoop.apache.org',
+      packages=["hadoop", 'hadoop.util', 'hadoop.io', 'hadoop.io.compress',
+                "hadoop.pydoop"],
+      extras_require = {
+        'pydoop': ['pydoop>=0.9.1']
+        }
+     )
+


### PR DESCRIPTION
Add `setup.py` file for installation. You can now install sequencefile as a Python package, `Hadoop`, by running `sudo python3 setup.py install` from the home directory of this repo.