### PR TITLE
In-memory SequenceFile Writer

### DIFF
--- a/hadoop/io/OutputStream.py
+++ b/hadoop/io/OutputStream.py
@@ -53,6 +53,24 @@ class FileOutputStream(OutputStream):
     def write(self, value):
         return self._fd.write(value)
 
+
+class BytesOutputStream(OutputStream):
+    def __init__(self, buffer):
+        self._buffer = buffer
+
+    def close(self):
+        pass
+
+    def getPos(self):
+        return len(self._buffer)
+
+    def writeByte(self, value):
+        self._buffer.extend(value)
+
+    def write(self, value):
+        self._buffer.extend(value)
+
+
 class DataOutputStream(object):
     def __init__(self, output_stream):
         assert isinstance(output_stream, OutputStream)


### PR DESCRIPTION
This PR adds a new `OutputStream` class which allows for writing a SequenceFile to an in-memory `bytearray` instead of to disk.