### PR TITLE
Execute Python utility tooling 2to3 on the codebase such that it can be run with Python 3.12.X

### DIFF
--- a/examples/ArrayFileTest.py
+++ b/examples/ArrayFileTest.py
@@ -22,7 +22,7 @@ from hadoop.io import ArrayFile
 if __name__ == '__main__':
     writer = ArrayFile.Writer('array-test', IntWritable)
     writer.INDEX_INTERVAL = 16
-    for i in xrange(0, 100):
+    for i in range(0, 100):
         writer.append(IntWritable(1 + i * 10))
     writer.close()
 
@@ -30,25 +30,25 @@ if __name__ == '__main__':
     value = IntWritable()
     reader = ArrayFile.Reader('array-test')
     while reader.next(key, value):
-        print key, value
+        print(key, value)
 
-    print 'GET 8'
-    print reader.get(8, value)
-    print value
-    print
+    print('GET 8')
+    print(reader.get(8, value))
+    print(value)
+    print()
 
-    print 'GET 110'
-    print reader.get(110, value)
-    print
+    print('GET 110')
+    print(reader.get(110, value))
+    print()
 
-    print 'GET 25'
-    print reader.get(25, value)
-    print value
-    print
+    print('GET 25')
+    print(reader.get(25, value))
+    print(value)
+    print()
 
-    print 'GET 55'
-    print reader.get(55, value)
-    print value
-    print
+    print('GET 55')
+    print(reader.get(55, value))
+    print(value)
+    print()
 
     reader.close()

--- a/examples/MapFileTest.py
+++ b/examples/MapFileTest.py
@@ -22,7 +22,7 @@ from hadoop.io import MapFile
 if __name__ == '__main__':
     writer = MapFile.Writer('map-test', LongWritable, LongWritable)
     writer.INDEX_INTERVAL = 2
-    for i in xrange(0, 100, 2):
+    for i in range(0, 100, 2):
         writer.append(LongWritable(i), LongWritable(i * 10))
     writer.close()
 
@@ -30,32 +30,32 @@ if __name__ == '__main__':
     value = LongWritable()
     reader = MapFile.Reader('map-test')
     while reader.next(key, value):
-        print key, value
+        print(key, value)
 
-    print 'MID KEY', reader.midKey()
-    print 'FINAL KEY', reader.finalKey(key), key
+    print('MID KEY', reader.midKey())
+    print('FINAL KEY', reader.finalKey(key), key)
 
-    print 'GET CLOSEST'
+    print('GET CLOSEST')
     key.set(8)
-    print reader.get(key, value)
-    print value
-    print
+    print(reader.get(key, value))
+    print(value)
+    print()
 
-    print 'GET 111'
+    print('GET 111')
     key.set(111)
-    print reader.get(key, value)
-    print
+    print(reader.get(key, value))
+    print()
 
     key.set(25)
-    print 'SEEK 25 before'
-    print reader.getClosest(key, value, before=True)
-    print value
-    print
+    print('SEEK 25 before')
+    print(reader.getClosest(key, value, before=True))
+    print(value)
+    print()
 
     key.set(55)
-    print 'SEEK 55'
-    print reader.getClosest(key, value)
-    print value
-    print
+    print('SEEK 55')
+    print(reader.getClosest(key, value))
+    print(value)
+    print()
 
     reader.close()

--- a/examples/SequenceFileMeta.py
+++ b/examples/SequenceFileMeta.py
@@ -25,10 +25,10 @@ def writeData(writer):
     key = LongWritable()
     value = LongWritable()
 
-    for i in xrange(10):
+    for i in range(10):
         key.set(1000 - i)
         value.set(i)
-        print '[%d] %s %s' % (writer.getLength(), key.toString(), value.toString())
+        print('[%d] %s %s' % (writer.getLength(), key.toString(), value.toString()))
         writer.append(key, value)
 
 def testWrite(filename):
@@ -45,7 +45,7 @@ def testRead(filename):
 
     metadata = reader.getMetadata()
     for meta_key, meta_value in metadata:
-        print 'METADATA:', meta_key, meta_value
+        print('METADATA:', meta_key, meta_value)
 
     key_class = reader.getKeyClass()
     value_class = reader.getValueClass()
@@ -55,8 +55,8 @@ def testRead(filename):
 
     position = reader.getPosition()
     while reader.next(key, value):
-        print '*' if reader.syncSeen() else ' ',
-        print '[%6s] %6s %6s' % (position, key.toString(), value.toString())
+        print('*' if reader.syncSeen() else ' ', end=' ')
+        print('[%6s] %6s %6s' % (position, key.toString(), value.toString()))
         position = reader.getPosition()
 
     reader.close()

--- a/examples/SequenceFileReader.py
+++ b/examples/SequenceFileReader.py
@@ -22,7 +22,7 @@ from hadoop.io import SequenceFile
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:
-        print 'usage: SequenceFileReader <filename>'
+        print('usage: SequenceFileReader <filename>')
     else:
         reader = SequenceFile.Reader(sys.argv[1])
 
@@ -35,8 +35,8 @@ if __name__ == '__main__':
         #reader.sync(4042)
         position = reader.getPosition()
         while reader.next(key, value):
-            print '*' if reader.syncSeen() else ' ',
-            print '[%6s] %6s %6s' % (position, key.toString(), value.toString())
+            print('*' if reader.syncSeen() else ' ', end=' ')
+            print('[%6s] %6s %6s' % (position, key.toString(), value.toString()))
             position = reader.getPosition()
 
         reader.close()

--- a/examples/SequenceFileWriterDemo.py
+++ b/examples/SequenceFileWriterDemo.py
@@ -24,10 +24,10 @@ def writeData(writer):
     key = LongWritable()
     value = LongWritable()
 
-    for i in xrange(1000):
+    for i in range(1000):
         key.set(1000 - i)
         value.set(i)
-        print '[%d] %s %s' % (writer.getLength(), key.toString(), value.toString())
+        print('[%d] %s %s' % (writer.getLength(), key.toString(), value.toString()))
         writer.append(key, value)
 
 if __name__ == '__main__':

--- a/examples/SetFileTest.py
+++ b/examples/SetFileTest.py
@@ -22,33 +22,33 @@ from hadoop.io import SetFile
 if __name__ == '__main__':
     writer = SetFile.Writer('set-test', IntWritable)
     writer.INDEX_INTERVAL = 16
-    for i in xrange(0, 100, 2):
+    for i in range(0, 100, 2):
         writer.append(IntWritable(i * 10))
     writer.close()
 
     key = IntWritable()
     reader = SetFile.Reader('set-test')
     while reader.next(key):
-        print key
+        print(key)
 
-    print 'GET 8'
+    print('GET 8')
     key.set(8)
-    print reader.get(key)
-    print
+    print(reader.get(key))
+    print()
 
-    print 'GET 120'
+    print('GET 120')
     key.set(120)
-    print reader.get(key)
-    print
+    print(reader.get(key))
+    print()
 
-    print 'GET 240'
+    print('GET 240')
     key.set(240)
-    print reader.get(key)
-    print
+    print(reader.get(key))
+    print()
 
-    print 'GET 550'
+    print('GET 550')
     key.set(550)
-    print reader.get(key)
-    print
+    print(reader.get(key))
+    print()
 
     reader.close()

--- a/hadoop/__init__.py
+++ b/hadoop/__init__.py
@@ -16,6 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
+from . import io
 from . import util
 

--- a/hadoop/io/FloatWritable.py
+++ b/hadoop/io/FloatWritable.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from Writable import AbstractValueWritable
+from .Writable import AbstractValueWritable
 
 class FloatWritable(AbstractValueWritable):
     def write(self, data_output):

--- a/hadoop/io/Lz4Codec.py
+++ b/hadoop/io/Lz4Codec.py
@@ -18,7 +18,7 @@
 
 import lz4_raw
 import struct
-from cStringIO import StringIO
+from io import StringIO
 
 from hadoop.io.InputStream import DataInputBuffer
 

--- a/hadoop/io/SequenceFile.py
+++ b/hadoop/io/SequenceFile.py
@@ -69,26 +69,26 @@ class Metadata(Writable):
         self._meta[name] = value
 
     def keys(self):
-        return self._meta.keys()
+        return list(self._meta.keys())
 
     def iterkeys(self):
-        return self._meta.iterkeys()
+        return iter(self._meta.keys())
 
     def values(self):
-        return self._meta.values()
+        return list(self._meta.values())
 
     def itervalues(self):
-        return self._meta.itervalues()
+        return iter(self._meta.values())
 
     def iteritems(self):
-        return self._meta.iteritems()
+        return iter(self._meta.items())
 
     def __iter__(self):
-        return self._meta.iteritems()
+        return iter(self._meta.items())
 
     def write(self, data_output):
         data_output.writeInt(len(self._meta))
-        for key, value in self._meta.items():
+        for key, value in list(self._meta.items()):
             Text.writeString(data_output, key)
             Text.writeString(data_output, value)
 
@@ -505,7 +505,7 @@ class Reader(object):
 
         # setup compression codec
         if self._decompress:
-            if self._version >= CUSTOM_COMPRESS_VERSION:
+            if self._version.to_bytes(1, byteorder="little") >= CUSTOM_COMPRESS_VERSION.encode():
                 codec_class = Text.readString(self._stream)
                 self._codec = CodecPool().getDecompressor(codec_class)
             else:

--- a/hadoop/io/WritableUtils.py
+++ b/hadoop/io/WritableUtils.py
@@ -26,7 +26,7 @@ def readVLong(data_input):
         return first_byte
 
     i = 0
-    for idx in xrange(length - 1):
+    for idx in range(length - 1):
         b = data_input.readUByte()
         i = i << 8
         i = i | b
@@ -53,7 +53,7 @@ def writeVLong(data_output, value):
 
     data_output.writeByte(length)
     length = -(length + 120) if (length < -120) else -(length + 112)
-    for idx in reversed(range(length)):
+    for idx in reversed(list(range(length))):
         shiftbits = idx << 3
         mask = 0xFF << shiftbits
 

--- a/hadoop/pydoop/reader.py
+++ b/hadoop/pydoop/reader.py
@@ -68,7 +68,7 @@ class SequenceFileReader(pp.RecordReader):
     def close(self):
         self.seq_file.close()
 
-    def next(self):
+    def __next__(self):
         if (self.seq_file.next(self._key, self._value)):
             return (True, self._key.toString(), self._value.toString())
         else:


### PR DESCRIPTION
Hi @chester-leung I know this library hasn’t seen attention for a number of years now. 
I’m working on the [Apache Nutch](https://nutch.apache.org) web crawler project, which still uses Hadoop sequence file data structures.
This PR offers two things
1. simply runs [2to3](https://docs.python.org/3/library/2to3.html) over the codebase
2. addresses a bug in `SequenceFile` where a check for the compression codec version (hex string) was not being correctly compared to an `int`.

Thanks